### PR TITLE
Allow using `semver` to determine the next version while releasing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,9 @@ the release and push it to the respective package manager.
 Maintain allows you to specify the `major`, `minor` or `patch` to automatically
 bump the respective version number, or you can explicitly specify a version.
 
+You may also specify `semver` as the version to automatically determine the
+next semantic version. This is not supported on all releasers.
+
 Pull-request
 ~~~~~~~~~~~~
 

--- a/maintain/commands/release.py
+++ b/maintain/commands/release.py
@@ -42,6 +42,10 @@ def release(version, dry_run, bump, pull_request, dependents):
 
     if not version and bump:
         raise MissingParameter(param_hint='version', param_type='argument')
+    elif version == 'semver':
+        version = releaser.determine_next_version()
+        if not version:
+            raise Exception('Could not determine the next semantic version.')
     elif version in ('major', 'minor', 'patch'):
         if bump:
             version = bump_version(releaser.determine_current_version(), version)

--- a/maintain/release/aggregate.py
+++ b/maintain/release/aggregate.py
@@ -62,6 +62,24 @@ class AggregateReleaser(Releaser):
     def determine_current_version(self):
         return self.releasers[0].determine_current_version()
 
+    def determine_next_version(self):
+        version = None
+        releaser_name = None
+
+        for releaser in self.releasers:
+            next_version = releaser.determine_next_version()
+            if not next_version:
+                continue
+
+            if version and version != next_version:
+                raise Exception('Inconsistent next versions, {} is at {} but {} is at {}.'.format(
+                                releaser_name, version, releaser.name, next_version))
+
+            version = next_version
+            releaser_name = releaser.name
+
+        return version
+
     def bump(self, new_version):
         for releaser in self.releasers:
             releaser.bump(new_version)

--- a/maintain/release/base.py
+++ b/maintain/release/base.py
@@ -22,6 +22,12 @@ class Releaser(object):
         """
         raise NotImplemented
 
+    def determine_next_version(self):
+        """
+        Called to determine the next version number.
+        """
+        return None
+
     def bump(self, new_version):
         """
         Called to bump the version number in the project.

--- a/maintain/release/changelog.py
+++ b/maintain/release/changelog.py
@@ -23,13 +23,16 @@ class ChangelogReleaser(Releaser):
             return Version(release.name)
 
     def determine_next_version(self):
+        current_version = self.determine_current_version()
+        if current_version.prerelease or current_version.build:
+            return None
+
         changelog = parse_changelog()
 
         for release in changelog.releases:
             if release.name != 'Master':
                 continue
 
-            current_version = self.determine_current_version()
             breaking = release.find_section('Breaking')
             enhancements = release.find_section('Enhancements')
             bug_fixes = release.find_section('Bug Fixes')

--- a/tests/release/fixtures/CHANGELOG-NEXT-MAJOR-UNSTABLE.md
+++ b/tests/release/fixtures/CHANGELOG-NEXT-MAJOR-UNSTABLE.md
@@ -1,0 +1,23 @@
+# swiftenv Changelog
+
+## Master
+
+### Breaking
+
+- `swiftenv uninstall` will now uninstall Swift toolchains on OS X.
+
+
+## 0.1.0 (2015-12-12)
+
+### Enhancements
+
+- Supports installing final Swift releases such as `2.2`.
+
+### Bug Fixes
+
+- Swift toolchains 'latest' version is no longer shown in `swiftenv versions`
+  on OS X.
+- Fixes a problem where `swiftenv install` on Linux will incorrectly
+  determine URL for the Swift binaries.
+- Adds a `--verbose` mode to `swiftenv versions` to show where the version was
+  installed.

--- a/tests/release/fixtures/CHANGELOG-NEXT-MAJOR.md
+++ b/tests/release/fixtures/CHANGELOG-NEXT-MAJOR.md
@@ -1,0 +1,23 @@
+# swiftenv Changelog
+
+## Master
+
+### Breaking
+
+- `swiftenv uninstall` will now uninstall Swift toolchains on OS X.
+
+
+## 1.0.0 (2015-12-12)
+
+### Enhancements
+
+- Supports installing final Swift releases such as `2.2`.
+
+### Bug Fixes
+
+- Swift toolchains 'latest' version is no longer shown in `swiftenv versions`
+  on OS X.
+- Fixes a problem where `swiftenv install` on Linux will incorrectly
+  determine URL for the Swift binaries.
+- Adds a `--verbose` mode to `swiftenv versions` to show where the version was
+  installed.

--- a/tests/release/fixtures/CHANGELOG-NEXT-MINOR.md
+++ b/tests/release/fixtures/CHANGELOG-NEXT-MINOR.md
@@ -1,0 +1,23 @@
+# swiftenv Changelog
+
+## Master
+
+### Enhancements
+
+- `swiftenv uninstall` will now uninstall Swift toolchains on OS X.
+
+
+## 1.0.2 (2015-12-12)
+
+### Enhancements
+
+- Supports installing final Swift releases such as `2.2`.
+
+### Bug Fixes
+
+- Swift toolchains 'latest' version is no longer shown in `swiftenv versions`
+  on OS X.
+- Fixes a problem where `swiftenv install` on Linux will incorrectly
+  determine URL for the Swift binaries.
+- Adds a `--verbose` mode to `swiftenv versions` to show where the version was
+  installed.

--- a/tests/release/fixtures/CHANGELOG-NEXT-PRERELEASE.md
+++ b/tests/release/fixtures/CHANGELOG-NEXT-PRERELEASE.md
@@ -1,0 +1,23 @@
+# swiftenv Changelog
+
+## Master
+
+### Enhancements
+
+- `swiftenv uninstall` will now uninstall Swift toolchains on OS X.
+
+
+## 1.0.2-beta.1 (2015-12-12)
+
+### Enhancements
+
+- Supports installing final Swift releases such as `2.2`.
+
+### Bug Fixes
+
+- Swift toolchains 'latest' version is no longer shown in `swiftenv versions`
+  on OS X.
+- Fixes a problem where `swiftenv install` on Linux will incorrectly
+  determine URL for the Swift binaries.
+- Adds a `--verbose` mode to `swiftenv versions` to show where the version was
+  installed.

--- a/tests/release/test_aggregate.py
+++ b/tests/release/test_aggregate.py
@@ -7,12 +7,19 @@ from maintain.release.aggregate import AggregateReleaser
 
 
 class TestReleaser(Releaser):
-    def __init__(self, current_version):
+    def __init__(self, current_version, next_version=None):
         self.current_version = Version(current_version)
+        if next_version:
+            self.next_version = Version(next_version)
+        else:
+            self.next_version = None
         self.is_released = False
 
     def determine_current_version(self):
         return self.current_version
+
+    def determine_next_version(self):
+        return self.next_version
 
     def bump(self, new_version):
         self.current_version = Version(new_version)
@@ -35,6 +42,30 @@ class AggregateReleaserTestCase(unittest.TestCase):
         releaser = AggregateReleaser(releasers=[TestReleaser('1.2.3')])
         version = releaser.determine_current_version()
         self.assertEqual(version, Version('1.2.3'))
+
+    def test_determine_next_version_unknown(self):
+        releaser = AggregateReleaser(releasers=[
+            TestReleaser('1.2.3'),
+            TestReleaser('1.2.3'),
+        ])
+        version = releaser.determine_next_version()
+        self.assertEqual(version, None)
+
+    def test_determine_next_version(self):
+        releaser = AggregateReleaser(releasers=[
+            TestReleaser('1.2.3'),
+            TestReleaser('1.2.3', '1.3.0'),
+        ])
+        version = releaser.determine_next_version()
+        self.assertEqual(version, Version('1.3.0'))
+
+    def test_determine_inconsistent_next_version(self):
+        releaser = AggregateReleaser(releasers=[
+            TestReleaser('1.2.3', '2.0.0'),
+            TestReleaser('1.2.3', '1.3.0'),
+        ])
+        with self.assertRaises(Exception):
+            releaser.determine_next_version()
 
     def test_bumping(self):
         releasers = [

--- a/tests/release/test_changelog.py
+++ b/tests/release/test_changelog.py
@@ -42,6 +42,15 @@ class ChangelogReleaserTestCase(unittest.TestCase):
             version = ChangelogReleaser().determine_next_version()
             self.assertEqual(version, Version('1.0.1'))
 
+    def test_determine_next_version_prerelease(self):
+        fixture_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')
+        changelog = os.path.join(fixture_path, 'CHANGELOG-NEXT-PRERELEASE.md')
+
+        with temp_directory():
+            shutil.copyfile(changelog, 'CHANGELOG.md')
+            version = ChangelogReleaser().determine_next_version()
+            self.assertIsNone(version)
+
     def test_determine_next_version_minor(self):
         fixture_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')
         changelog = os.path.join(fixture_path, 'CHANGELOG-NEXT-MINOR.md')

--- a/tests/release/test_changelog.py
+++ b/tests/release/test_changelog.py
@@ -33,6 +33,42 @@ class ChangelogReleaserTestCase(unittest.TestCase):
             version = ChangelogReleaser().determine_current_version()
             self.assertEqual(version, Version('1.0.0'))
 
+    def test_determine_next_version_patch(self):
+        fixture_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')
+        changelog = os.path.join(fixture_path, 'CHANGELOG.md')
+
+        with temp_directory():
+            shutil.copyfile(changelog, 'CHANGELOG.md')
+            version = ChangelogReleaser().determine_next_version()
+            self.assertEqual(version, Version('1.0.1'))
+
+    def test_determine_next_version_minor(self):
+        fixture_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')
+        changelog = os.path.join(fixture_path, 'CHANGELOG-NEXT-MINOR.md')
+
+        with temp_directory():
+            shutil.copyfile(changelog, 'CHANGELOG.md')
+            version = ChangelogReleaser().determine_next_version()
+            self.assertEqual(version, Version('1.1.0'))
+
+    def test_determine_next_version_major(self):
+        fixture_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')
+        changelog = os.path.join(fixture_path, 'CHANGELOG-NEXT-MAJOR.md')
+
+        with temp_directory():
+            shutil.copyfile(changelog, 'CHANGELOG.md')
+            version = ChangelogReleaser().determine_next_version()
+            self.assertEqual(version, Version('2.0.0'))
+
+    def test_determine_next_version_major_unstable(self):
+        fixture_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')
+        changelog = os.path.join(fixture_path, 'CHANGELOG-NEXT-MAJOR-UNSTABLE.md')
+
+        with temp_directory():
+            shutil.copyfile(changelog, 'CHANGELOG.md')
+            version = ChangelogReleaser().determine_next_version()
+            self.assertEqual(version, Version('0.2.0'))
+
     @mock.patch('maintain.release.changelog.date', FakeDate)
     def test_bumps_master(self):
         from datetime import date


### PR DESCRIPTION
When a user uses a semantic changelog, we can determine the next possible version to release. This allows the following:

```shell
$ maintain release semver
```

Where maintain will determine the next version number to use while releasing.