### PR TITLE
Add `repo` subcommand to operate on collection of repos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,7 @@ Maintain supports the following releasers:
 .. toctree::
    :maxdepth: 1
 
+   repo
    release/hooks
    release/git
    release/github

--- a/docs/repo.rst
+++ b/docs/repo.rst
@@ -33,3 +33,12 @@ Options
 
 -s/--silent - Don't print subcommand output
 --exit - Exit after first failure (non zero exit)
+
+cp
+--
+
+Copies a file into each repository.
+
+.. code-block::
+
+    $ maintain repo cp contributing.md .github/CONTRIBUTING.md

--- a/docs/repo.rst
+++ b/docs/repo.rst
@@ -1,0 +1,23 @@
+Repo
+====
+
+Commands to operate on a collection of repositories at a time.
+
+print
+-----
+
+Subcommand to print all matched repositories, this is useful to test which repositories will be used for other operations.
+
+run
+---
+
+Allows running the provided command on a collection of repositories.
+
+.. code-block::
+
+    $ maintain repo run 'npm install && npm test'
+
+Options
+
+-s/--silent - Don't print subcommand output
+--exit - Exit after first failure (non zero exit)

--- a/docs/repo.rst
+++ b/docs/repo.rst
@@ -8,6 +8,18 @@ print
 
 Subcommand to print all matched repositories, this is useful to test which repositories will be used for other operations.
 
+check
+-----
+
+Checks all repositories for unstaged, unsynced or untracked changes.
+
+.. code-block::
+
+    $ maintain repo check
+    goji
+     - Branch is not master
+     - Repository has unstaged changes
+
 run
 ---
 

--- a/maintain/commands/__init__.py
+++ b/maintain/commands/__init__.py
@@ -1,6 +1,7 @@
 import click
 
 from maintain.commands.release import release
+from maintain.commands.repo import repo
 
 
 @click.group()
@@ -9,3 +10,4 @@ def cli():
 
 
 cli.add_command(release)
+cli.add_command(repo)

--- a/maintain/commands/repo.py
+++ b/maintain/commands/repo.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+from shutil import copyfile
 
 import click
 from git import Repo
@@ -99,5 +100,25 @@ def check(exit):
 
                 if exit:
                     break
+
+    sys.exit(status)
+
+
+@repo.command()
+@click.argument('src', nargs=-1, type=click.Path(exists=True))
+@click.argument('dst', nargs=1, type=click.Path())
+def cp(src, dst):
+    status = 0
+
+    for (repo, path) in gather_repositories():
+        for filename in src:
+            destination = os.path.join(path, dst)
+
+            if os.path.exists(destination):
+                status = 1
+                print('Cannot copy to {}, {} exists'.format(repo, dst))
+                continue
+
+            copyfile(filename, destination)
 
     sys.exit(status)

--- a/maintain/commands/repo.py
+++ b/maintain/commands/repo.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import subprocess
+
+import click
+from git import Repo
+
+from maintain.process import chdir
+
+
+def gather_repositories():
+    """
+    Collects all of the repositories. The current implementation
+    searches for them in the current working directory.
+    """
+
+    for (root, dirs, files) in os.walk('.'):
+        basename = os.path.basename(root)
+
+        if basename != '.git':
+            continue
+
+        path= os.path.split(root)[0]
+        repo = os.path.basename(path)
+        yield (repo, path)
+
+
+@click.group()
+def repo():
+    pass
+
+
+@repo.command('print')
+def print_command():
+    """
+    Prints all repos.
+    """
+
+    for (repo, path) in gather_repositories():
+        print(repo)
+
+
+@repo.command()
+@click.argument('command', nargs=-1)
+@click.option('--exit/--no-exit', default=False)
+@click.option('--silent/--no-silent', '-s', default=False)
+def run(command, exit, silent):
+    """
+    Runs given command on all repos and checks status
+
+        $ maintain repo run -- git checkout master
+    """
+
+    status = 0
+
+    for (repo, path) in gather_repositories():
+        with chdir(path):
+            result = subprocess.run(command, shell=True, capture_output=silent)
+            if result.returncode != 0:
+                status = result.returncode
+
+                print('Command failed: {}'.format(repo))
+
+                if exit:
+                    break
+
+    sys.exit(status)

--- a/maintain/commands/repo.py
+++ b/maintain/commands/repo.py
@@ -65,3 +65,38 @@ def run(command, exit, silent):
                     break
 
     sys.exit(status)
+
+
+@repo.command()
+@click.option('--exit/--no-exit', default=False)
+def check(exit):
+    status = 0
+
+    for (name, path) in gather_repositories():
+        with chdir(path):
+            repo = Repo()
+            failures = []
+
+            if repo.head.ref != repo.heads.master:
+                failures.append('Branch is not master')
+
+            if repo.is_dirty():
+                failures.append('Repository has unstaged changes')
+
+            if len(repo.untracked_files) > 0:
+                failures.append('Repository has untracked files')
+
+            if repo.remotes.origin.refs.master.commit != repo.head.ref.commit:
+                failures.append('Branch has unsynced changes')
+
+            if len(failures) > 0:
+                status = 1
+                print(name)
+
+                for failure in failures:
+                    print(' - {}'.format(failure))
+
+                if exit:
+                    break
+
+    sys.exit(status)

--- a/maintain/commands/repo.py
+++ b/maintain/commands/repo.py
@@ -14,15 +14,16 @@ def gather_repositories():
     searches for them in the current working directory.
     """
 
-    for (root, dirs, files) in os.walk('.'):
-        basename = os.path.basename(root)
-
-        if basename != '.git':
+    for (root, dirs, files) in os.walk('.', topdown=True):
+        if '.git' not in dirs:
             continue
 
-        path= os.path.split(root)[0]
+        for dir in list(dirs):
+            dirs.remove(dir)
+
+        path = os.path.split(root)[1]
         repo = os.path.basename(path)
-        yield (repo, path)
+        yield (repo, root)
 
 
 @click.group()


### PR DESCRIPTION
Sometimes you might want to perform some bulk operation on a collection of repositories, for example adding and committing a file. Checking they are all synced, or even running reports by checking a collection of repositories.

The `maintain repo` group brings a collection of sub-commands to operate on multiple repos. Right now it looks for all `.git` repos in subdirectories, in the future I want to be able to provide configuration or dynamic providers. You should be be able to define the repos to use and their paths in a config file so that you can use them to perform actions even if you don't have repos locally, for example mass `cloning` all of them on a new system. Another type of repo list "provider" I'd like to see is a dynamic one, for example to populate all of the repos in a GitHub org or user so that you can mass clone an entire org/user.

---

1. Does the `repo` name make sense for subcommand? Could `git` or `repos` make more sense?