### PR TITLE
Refactor Configuration and provide full validation

### DIFF
--- a/maintain/commands/release.py
+++ b/maintain/commands/release.py
@@ -4,9 +4,9 @@ import logging
 
 import click
 from click.exceptions import MissingParameter, ClickException
-import yaml
 from semantic_version import Version
 
+from maintain.config import Configuration
 from maintain.release.aggregate import AggregateReleaser
 from maintain.release.git_releaser import GitReleaser
 from maintain.release.github import GitHubReleaser
@@ -30,13 +30,9 @@ def release(version, dry_run, bump, pull_request, verbose):
     if verbose:
         logger.setLevel(logging.DEBUG)
 
-    if os.path.exists('.maintain.yml'):
-        with open('.maintain.yml') as fp:
-            config = yaml.load(fp.read())
-    else:
-        config = {}
+    config = Configuration.load()
 
-    releaser = AggregateReleaser(config.get('release', {}))
+    releaser = AggregateReleaser(config.release)
 
     git_releasers = filter(lambda releaser: isinstance(releaser, GitReleaser), releaser.releasers)
     github_releasers = filter(lambda releaser: isinstance(releaser, GitHubReleaser), releaser.releasers)

--- a/maintain/config.py
+++ b/maintain/config.py
@@ -1,6 +1,18 @@
 import os
 
 import yaml
+import jsonschema
+
+
+SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'release': {
+            'type': 'object'
+            # TODO variable properties to object
+        }
+    }
+}
 
 
 class Configuration(object):
@@ -27,9 +39,16 @@ class Configuration(object):
     @classmethod
     def fromfile(cls, path):
         with open(path) as fp:
-            content = yaml.load(fp.read())
+            content = fp.read()
+            content = yaml.load(content)
+            cls.validate(content)
 
         return cls(**content)
+
+    @classmethod
+    def validate(cls, config):
+        jsonschema.validate(config, SCHEMA)
+        return True
 
     def __init__(self, release=None):
         self.release = release or {}

--- a/maintain/config.py
+++ b/maintain/config.py
@@ -3,12 +3,15 @@ import os
 import yaml
 import jsonschema
 
+from maintain.release.aggregate import AggregateReleaser
+
 
 SCHEMA = {
     'type': 'object',
     'properties': {
         'release': {
             'type': 'object',
+            'properties': {},
             'patternProperties': {
                 '': {
                     'type': 'object'
@@ -17,6 +20,13 @@ SCHEMA = {
         }
     }
 }
+
+
+for releaser in AggregateReleaser.releasers():
+    if not releaser.schema():
+        continue
+
+    SCHEMA['properties']['release']['properties'][releaser.config_name()] = releaser.schema()
 
 
 class Configuration(object):

--- a/maintain/config.py
+++ b/maintain/config.py
@@ -8,8 +8,12 @@ SCHEMA = {
     'type': 'object',
     'properties': {
         'release': {
-            'type': 'object'
-            # TODO variable properties to object
+            'type': 'object',
+            'patternProperties': {
+                '': {
+                    'type': 'object'
+                }
+            }
         }
     }
 }

--- a/maintain/config.py
+++ b/maintain/config.py
@@ -1,0 +1,35 @@
+import os
+
+import yaml
+
+
+class Configuration(object):
+    @classmethod
+    def load(cls):
+        paths = [
+            '.maintain.yml',
+            '.maintain.yaml',
+            '.maintain/config.yml',
+            '.maintain/config.yaml',
+        ]
+
+        found_paths = list(filter(os.path.exists, paths))
+
+        if len(found_paths) == 0:
+            return cls()
+
+        if len(found_paths) > 1:
+            paths = ', '.join(found_paths)
+            raise Exception('Multiple configuration files found: {}'.format(paths))
+
+        return cls.fromfile(found_paths[0])
+
+    @classmethod
+    def fromfile(cls, path):
+        with open(path) as fp:
+            content = yaml.load(fp.read())
+
+        return cls(**content)
+
+    def __init__(self, release=None):
+        self.release = release or {}

--- a/maintain/release/aggregate.py
+++ b/maintain/release/aggregate.py
@@ -42,7 +42,7 @@ class AggregateReleaser(Releaser):
 
         def get_config(releaser):
             if config:
-                return config.get(releaser.name.lower().replace(' ', '_'), {})
+                return config.get(releaser.config_name(), {})
 
             return {}
 

--- a/maintain/release/base.py
+++ b/maintain/release/base.py
@@ -16,6 +16,20 @@ class Releaser(object):
 
         return False
 
+    @classmethod
+    def config_name(cls):
+        """
+        The releasers configuration key.
+        """
+        return cls.name.lower().replace(' ', '_')
+
+    @classmethod
+    def schema(cls):
+        """
+        Returns a schema for validating the configuration for the releaser.
+        """
+        return None
+
     def __init__(self, config=None):
         pass
 

--- a/maintain/release/git_releaser.py
+++ b/maintain/release/git_releaser.py
@@ -17,6 +17,21 @@ class GitReleaser(Releaser):
     def detect(cls):
         return os.path.exists('.git')
 
+    @classmethod
+    def schema(cls):
+        return {
+            'type': 'object',
+            'properties': {
+                'commit_format': {
+                    'type': 'string'
+                },
+                'tag_format': {
+                    'type': 'string'
+                },
+            },
+            'additionalProperties': False,
+        }
+
     def __init__(self, config=None):
         self.repo = Repo()
 

--- a/maintain/release/github.py
+++ b/maintain/release/github.py
@@ -27,6 +27,21 @@ class GitHubReleaser(Releaser):
 
         return url.startswith('https://github.com') or url.startswith('git@github.com')
 
+    @classmethod
+    def schema(cls):
+        return {
+            'type': 'object',
+            'properties': {
+                'artefacts': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string'
+                    }
+                }
+            },
+            'additionalProperties': False,
+        }
+
     def __init__(self, config):
         if not cmd_exists('hub'):
             raise Exception('GitHub releases require hub. Missing dependency for hub: https://github.com/github/hub. Please install `hub` and try again.')

--- a/maintain/release/hooks.py
+++ b/maintain/release/hooks.py
@@ -15,6 +15,30 @@ class HookReleaser(Releaser):
     def detect(cls):
         return True
 
+    @classmethod
+    def schema(cls):
+        hook = {
+            'type': 'object',
+            'properties': {
+                'pre': {
+                    'type': 'array',
+                    'items': {'type': 'string'}
+                },
+                'post': {
+                    'type': 'array',
+                    'items': {'type': 'string'}
+                }
+            }
+        }
+        return {
+            'type': 'object',
+            'properties': {
+                'bump': hook,
+                'publish': hook,
+            },
+            'additionalProperties': False,
+        }
+
     def __init__(self, config):
         self.bump_commands = []
         self.release_commands = []

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'pyyaml',
         'commonmark==0.6.3',
         'gitpython',
+        'jsonschema',
     ],
     author='Kyle Fuller',
     author_email='kyle@fuller.li',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,3 +46,10 @@ class ConfigurationTests(unittest.TestCase):
 
             with self.assertRaises(Exception):
                 Configuration.load()
+
+    def test_loading_file_validation(self):
+        with temp_directory():
+            touch('.maintain.yml', 'release: []')
+
+            with self.assertRaises(Exception):
+                Configuration.load()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,48 @@
+import unittest
+
+from maintain.config import Configuration
+
+from tests.utils import temp_directory, touch
+
+
+class ConfigurationTests(unittest.TestCase):
+    def test_loading_no_file(self):
+        with temp_directory():
+            configuration = Configuration.load()
+            self.assertEqual(configuration.release, {})
+
+    def test_loading_file_maintain_yml(self):
+        with temp_directory():
+            touch('.maintain.yml', 'release:\n  test: value')
+
+            configuration = Configuration.load()
+            self.assertEqual(configuration.release.get('test'), 'value')
+
+    def test_loading_file_maintain_yaml(self):
+        with temp_directory():
+            touch('.maintain.yaml', 'release:\n  test: value')
+
+            configuration = Configuration.load()
+            self.assertEqual(configuration.release.get('test'), 'value')
+
+    def test_loading_file_config_maintain_yml(self):
+        with temp_directory():
+            touch('.maintain/config.yml', 'release:\n  test: value')
+
+            configuration = Configuration.load()
+            self.assertEqual(configuration.release.get('test'), 'value')
+
+    def test_loading_file_config_maintain_yaml(self):
+        with temp_directory():
+            touch('.maintain/config.yaml', 'release:\n  test: value')
+
+            configuration = Configuration.load()
+            self.assertEqual(configuration.release.get('test'), 'value')
+
+    def test_loading_multiple_file(self):
+        with temp_directory():
+            touch('.maintain.yaml')
+            touch('.maintain.yml')
+
+            with self.assertRaises(Exception):
+                Configuration.load()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,3 +63,25 @@ class ConfigurationTests(unittest.TestCase):
     def test_validate_release_releaser_object(self):
         with self.assertRaises(Exception):
             Configuration.validate({'release': {'test': []}})
+
+    def test_validate_valid_releaser(self):
+        Configuration.validate({
+            'release': {
+                'git': {
+                    'commit_format': 'Hello World',
+                    'tag_format': '{version}',
+                }
+            }
+        })
+
+    def test_validate_invalid_releaser(self):
+        with self.assertRaises(Exception):
+            Configuration.validate({
+                'release': {
+                    'git': {
+                        'commit_format': 'Hello World',
+                        'tag_format': '{version}',
+                        'unknown': 'x',
+                    }
+                }
+            })

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,31 +13,31 @@ class ConfigurationTests(unittest.TestCase):
 
     def test_loading_file_maintain_yml(self):
         with temp_directory():
-            touch('.maintain.yml', 'release:\n  test: value')
+            touch('.maintain.yml', 'release:\n  test: {}')
 
             configuration = Configuration.load()
-            self.assertEqual(configuration.release.get('test'), 'value')
+            self.assertEqual(configuration.release.get('test'), {})
 
     def test_loading_file_maintain_yaml(self):
         with temp_directory():
-            touch('.maintain.yaml', 'release:\n  test: value')
+            touch('.maintain.yaml', 'release:\n  test: {}')
 
             configuration = Configuration.load()
-            self.assertEqual(configuration.release.get('test'), 'value')
+            self.assertEqual(configuration.release.get('test'), {})
 
     def test_loading_file_config_maintain_yml(self):
         with temp_directory():
-            touch('.maintain/config.yml', 'release:\n  test: value')
+            touch('.maintain/config.yml', 'release:\n  test: {}')
 
             configuration = Configuration.load()
-            self.assertEqual(configuration.release.get('test'), 'value')
+            self.assertEqual(configuration.release.get('test'), {})
 
     def test_loading_file_config_maintain_yaml(self):
         with temp_directory():
-            touch('.maintain/config.yaml', 'release:\n  test: value')
+            touch('.maintain/config.yaml', 'release:\n  test: {}')
 
             configuration = Configuration.load()
-            self.assertEqual(configuration.release.get('test'), 'value')
+            self.assertEqual(configuration.release.get('test'), {})
 
     def test_loading_multiple_file(self):
         with temp_directory():
@@ -52,4 +52,14 @@ class ConfigurationTests(unittest.TestCase):
             touch('.maintain.yml', 'release: []')
 
             with self.assertRaises(Exception):
-                Configuration.load()
+                configuration.load()
+
+    # Validation
+
+    def test_validate_release_object(self):
+        with self.assertRaises(Exception):
+            Configuration.validate({'release': []})
+
+    def test_validate_release_releaser_object(self):
+        with self.assertRaises(Exception):
+            Configuration.validate({'release': {'test': []}})


### PR DESCRIPTION
- Configuration is now owned by an object
- Configuration supports looking up in various locations.
- Configuration is validated.
- Releasers can hook into configuration validation.