### PR TITLE
Unpin commonmark version to fix html escaping bug in modern pythons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "click",
         "semantic_version",
         "pyyaml",
-        "commonmark==0.9.1",
+        "commonmark",
         "gitpython",
         "jsonschema",
     ],


### PR DESCRIPTION
What's up Kyle!

Maintain poops the bed on a fresh install on modern python versions:

```
Traceback (most recent call last):
  File "/Users/james/.local/bin/maintain", line 5, in <module>
    from maintain.commands import cli
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/maintain/commands/__init__.py", line 3, in <module>
    from maintain.commands.release import release
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/maintain/commands/release.py", line 20, in <module>
    from maintain.release.aggregate import AggregateReleaser
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/maintain/release/aggregate.py", line 7, in <module>
    from maintain.release.changelog import ChangelogReleaser
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/maintain/release/changelog.py", line 7, in <module>
    import CommonMark
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/CommonMark/__init__.py", line 2, in <module>
    from CommonMark.CommonMark import HtmlRenderer
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/CommonMark/CommonMark.py", line 14, in <module>
    from CommonMark.blocks import Parser
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/CommonMark/blocks.py", line 5, in <module>
    from CommonMark import common
  File "/Users/james/.local/share/uv/tools/maintain/lib/python3.10/site-packages/CommonMark/common.py", line 14, in <module>
    HTMLunescape = html.parser.HTMLParser().unescape
AttributeError: 'HTMLParser' object has no attribute 'unescape'
```

The previously pinned version of `commonmark` was referencing functions which have now been removed from the python standard library.

I unpinned the version and everything seems to "just work" ™️ but let me know if there was a reason for pinning only commonmark to a specific version.